### PR TITLE
Fix kinect color

### DIFF
--- a/FroxKinect2/Kinect2Device.cpp
+++ b/FroxKinect2/Kinect2Device.cpp
@@ -433,8 +433,8 @@ void Kinect2Device::UpdateColor()
 	// Read data
 	if (SUCCEEDED(hr))
 	{
-		auto dst = _depthFrame->GetData<uint16_t>();
-		auto frameSize = _depthFrame->GetSize();
+		auto dst = _colorFrame->GetData<uint8_t>();
+		auto frameSize = _colorFrame->GetSize();
 
 		if (imageFormat == ColorImageFormat_Bgra)
 		{
@@ -443,8 +443,8 @@ void Kinect2Device::UpdateColor()
 		}
 		else
 		{
-			assert(_depthFrame->GetElementSize() == sizeof(uint16_t) * 4);
-			
+			assert(_colorFrame->GetElementSize() == sizeof(uint8_t) * 4);
+
 			nBufferSize = frameSize.Width * frameSize.Height * sizeof(uint8_t) * 4;
 			hr = pColorFrame->CopyConvertedFrameDataToArray(nBufferSize, reinterpret_cast<BYTE*>(dst), ColorImageFormat::ColorImageFormat_Bgra);
 		}
@@ -516,7 +516,7 @@ void Kinect2Device::UpdateInfrared()
 	// Read data
 	if (SUCCEEDED(hr))
 	{
-		auto dst = _depthFrame->GetData<uint16_t>();
+		auto dst = _infraredFrame->GetData<uint16_t>();
 		memcpy(dst, pBuffer, nBufferSize);
 	}
 

--- a/FroxKinect2/Kinect2Device.cpp
+++ b/FroxKinect2/Kinect2Device.cpp
@@ -147,7 +147,7 @@ void Kinect2Device::InitFrames()
 		_colorFrameReader->put_IsPaused(TRUE);
 
 		IFrameDescription* pFrameDescription = nullptr;
-		pFrameSource->get_FrameDescription(&pFrameDescription);
+		pFrameSource->CreateFrameDescription(ColorImageFormat::ColorImageFormat_Bgra, &pFrameDescription);
 		if (pFrameDescription != nullptr)
 		{
 			_colorFrame = CreateColorFrame(pFrameDescription);

--- a/FroxKinect2/Utils.cpp
+++ b/FroxKinect2/Utils.cpp
@@ -68,7 +68,7 @@ ComputeFramePtr CreateFrame(IDepthFrameSource* pFrameSource)
 ComputeFramePtr CreateFrame(IColorFrameSource* pFrameSource)
 {
 	IFrameDescription* pFrameDescription = nullptr;
-	pFrameSource->get_FrameDescription(&pFrameDescription);
+	pFrameSource->CreateFrameDescription(ColorImageFormat::ColorImageFormat_Bgra, &pFrameDescription);
 	if (pFrameDescription != nullptr)
 	{
 		auto frame = CreateColorFrame(pFrameDescription);


### PR DESCRIPTION
### Исправлено получение FrameDescription при инициализации Color фрейма. 
Была проблема в том, что если инициализировать FrameDescription так: 
`pFrameSource->get_FrameDescription(&pFrameDescription);`
то значение bytesPerPixel было не верным и дальше срабатывал assert, проверяющий это число


### Исправлено обновление ColorFrame и DepthFrame
В методах UpdateColor и UpdateInfrared вместо _colorFrame и _infraredFrame использовался _depthFrame